### PR TITLE
fix: use proper tag for bouquets select

### DIFF
--- a/config-demo.yaml
+++ b/config-demo.yaml
@@ -1,6 +1,7 @@
 # overload with your own config file
 env: demo
 topic: univers-ecospheres
+tag: ecospheres
 grist_url: "https://grist.numerique.gouv.fr/o/ecospheres/api/docs/k3YQHL3Bmrhmpk8frjznZL/tables/Universe/records"
 api:
   url: https://demo.data.gouv.fr

--- a/config-prod.yaml
+++ b/config-prod.yaml
@@ -1,6 +1,7 @@
 # overload with your own config file
 env: prod
 topic: univers-ecospheres
+tag: univers-ecospheres
 grist_url: "https://grist.numerique.gouv.fr/o/ecospheres/api/docs/k3YQHL3Bmrhmpk8frjznZL/tables/Universe/records"
 api:
   url: https://www.data.gouv.fr

--- a/ecospheres_universe/feed_universe.py
+++ b/ecospheres_universe/feed_universe.py
@@ -346,7 +346,7 @@ def feed_universe(
 
     # Build a list of organizations from the list of bouquets
     print("Fetching organizations from bouquets...")
-    bouquets = api.get_bouquets(conf["topic"])
+    bouquets = api.get_bouquets(conf["tag"])
     bouquet_orgs = list(
         {
             o["id"]: Organization(id=o["id"], name=o["name"], slug=o["slug"], type=None)


### PR DESCRIPTION
NB: the data.gouv.fr db migration created some Topics with the prod tag on demo, which pollutes `tag=univers-ecospheres` on demo (I'll do a cleanup).