### PR TITLE
refactor: make datagouv.Organization sortable

### DIFF
--- a/ecospheres_universe/check_sync.py
+++ b/ecospheres_universe/check_sync.py
@@ -30,12 +30,10 @@ def check_sync(universe: Path, *extra_configs: Path):
 
     grist = GristApi(base_url=conf.grist_url, env=conf.env)
 
-    grist_orgs = grist.get_organizations()
-    grist_orgs = sorted(grist_orgs, key=lambda o: o.slug)
-
     topic_id = datagouv.get_topic_id(conf.topic)
 
     orgs = set[Organization]()
+    grist_orgs = grist.get_organizations()
     for grist_org in grist_orgs:
         org = datagouv.get_organization(grist_org.slug)
         if not org:
@@ -44,7 +42,7 @@ def check_sync(universe: Path, *extra_configs: Path):
         orgs.add(org)
 
     nb_errors = 0
-    for org in orgs:
+    for org in sorted(orgs):
         datasets_wo_es = datagouv.get_topic_datasets_count(topic_id, org.id, use_search=False)
         datasets_w_es = datagouv.get_topic_datasets_count(topic_id, org.id, use_search=True)
         if datasets_w_es == datasets_wo_es:

--- a/ecospheres_universe/datagouv.py
+++ b/ecospheres_universe/datagouv.py
@@ -2,9 +2,16 @@ import requests
 
 from dataclasses import dataclass
 from enum import Enum
+from functools import total_ordering
 from typing import Any, Callable
 
-from ecospheres_universe.util import batched, elapsed, elapsed_and_count, verbose_print
+from ecospheres_universe.util import (
+    batched,
+    elapsed,
+    elapsed_and_count,
+    normalize_string,
+    verbose_print,
+)
 
 
 session = requests.Session()
@@ -21,11 +28,17 @@ class Element:
     object_id: str
 
 
+@total_ordering
 @dataclass(frozen=True)
 class Organization:
     id: str
     name: str
     slug: str
+
+    def __lt__(self, other):
+        self_name = normalize_string(self.name)
+        other_name = normalize_string(other.name)
+        return self_name < other_name or (self_name == other_name and self.slug < other.slug)
 
 
 @dataclass(frozen=True)

--- a/ecospheres_universe/feed_universe.py
+++ b/ecospheres_universe/feed_universe.py
@@ -8,8 +8,6 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from shutil import copyfile
 
-import unicodedata
-
 from minicli import cli, run
 
 from ecospheres_universe.config import Config
@@ -27,17 +25,6 @@ REMOVALS_THRESHOLD = 1800
 @dataclass(frozen=True)
 class UniverseOrg(Organization):
     type: str | None = None  # TODO: rename to category !! impacts dashboard-backend
-
-
-def sort_orgs_by_name(orgs: list[UniverseOrg]) -> list[UniverseOrg]:
-    """Sort organizations by normalized name"""
-    return sorted(
-        orgs,
-        key=lambda o: unicodedata.normalize("NFKD", o.name)
-        .encode("ascii", "ignore")
-        .decode("ascii")
-        .lower(),
-    )
 
 
 def write_organizations_file(filepath: Path, orgs: list[UniverseOrg]):
@@ -167,7 +154,7 @@ def feed(
 
             write_organizations_file(
                 conf.output_dir / f"organizations-{element_class.value}-{conf.env}.json",
-                sort_orgs_by_name(upcoming_orgs),
+                sorted(upcoming_orgs),
             )
 
         # FIXME: remove when front uses the new file path
@@ -190,7 +177,7 @@ def feed(
         )
         write_organizations_file(
             conf.output_dir / f"organizations-bouquets-{conf.env}.json",
-            sort_orgs_by_name(bouquet_orgs),
+            sorted(bouquet_orgs),
         )
 
     finally:

--- a/ecospheres_universe/util.py
+++ b/ecospheres_universe/util.py
@@ -1,5 +1,6 @@
 import functools
 import time
+import unicodedata
 
 from collections.abc import Generator
 
@@ -37,6 +38,11 @@ def elapsed(func):
         return val
 
     return wrapper_decorator
+
+
+def normalize_string(string: str) -> str:
+    """Return NFKD-normalized, ascii-folded, lowercased form of the input string"""
+    return unicodedata.normalize("NFKD", string).encode("ascii", "ignore").decode("ascii").lower()
 
 
 # noop unless args.verbose is set


### PR DESCRIPTION
Found some cases where two orgs have the same normalized name (eg ECOLAB vs Ecolab) => stabilize the ordering on slug.

Took the opportunity to make Organization directly sortable rather than extract a rather adhoc `sort_orgs_by_foo_and_bar` into `util.py`.