### PR TITLE
feat: separate artifacts branch

### DIFF
--- a/.github/workflows/update-universes.yml
+++ b/.github/workflows/update-universes.yml
@@ -75,10 +75,10 @@ jobs:
           git pull --rebase origin ${{ github.ref_name }}
           git push
           # -- end remove --
-          cd ${{ env.WORKTREE }}
+          pushd ${{ env.WORKTREE }}
           git add .
           git commit --no-verify -m "workflow: update daily run for ${{ matrix.universe }}"
           git pull --rebase origin ${{ env.ARTIFACTS_BRANCH }}
           git push
-          cd -
+          popd
           git worktree remove ${{ env.WORKTREE }}


### PR DESCRIPTION
Fix https://github.com/opendatateam/udata-front-kit/issues/1069

Record `dist/*` and `logs/*` outputs to a separate (orphan) [`artifacts`](https://github.com/ecolabdata/ecospheres-universe/tree/artifacts) branch.

I fused the two dist and logs commits into one because I don't really see a point in having them separate, but I can revert that part if needed. Same for git commands, I don't really see a point in having push separate from the rest?

We still commit `dist`/`logs` to `main` as well until the front-end switches to the new paths. Once done, we'll be able to entirely remove the `dist` and `logs` folders from `main`.