### PR TITLE
feat: make config.tag optional

### DIFF
--- a/configs/culture-demo.yaml
+++ b/configs/culture-demo.yaml
@@ -1,6 +1,5 @@
 # WARNING: overload tokens with envvars or a separate config file to avoid leaking secrets
 topic: univers-culture
-tag: culture
 datagouv:
   url: https://demo.data.gouv.fr
   token: CONFIGURE_ME

--- a/configs/culture-prod.yaml
+++ b/configs/culture-prod.yaml
@@ -1,6 +1,5 @@
 # WARNING: overload tokens with envvars or a separate config file to avoid leaking secrets
 topic: univers-culture
-tag: culture
 datagouv:
   url: https://www.data.gouv.fr
   token: CONFIGURE_ME

--- a/ecospheres_universe/config.py
+++ b/ecospheres_universe/config.py
@@ -22,7 +22,7 @@ class GristConfig:
 @dataclass
 class Config:
     topic: str
-    tag: str
+    tag: str | None
     datagouv: DatagouvConfig
     grist: GristConfig
     output_dir: Path = Path("dist")

--- a/ecospheres_universe/feed_universe.py
+++ b/ecospheres_universe/feed_universe.py
@@ -267,22 +267,22 @@ def feed(
                 f"dist/organizations-{object_class.namespace()}-{env}.json",
             )
 
-        # TODO: custom ecologie => make that an option?
-        # TODO: can this be handled by the main update loop? datasets/services in bouquets should also be in universe?
-        verbose_print("Fetching additional organizations from bouquets...")
-        bouquets = datagouv.get_bouquets(conf.tag)
-        print(f"Found {len(bouquets)} bouquets with the universe tag.")
-        bouquet_orgs = uniquify(org for b in bouquets if (org := b.organization))
-        write_organizations_file(
-            conf.output_dir / "organizations-bouquets.json",
-            sorted(bouquet_orgs),
-        )
-        # FIXME: remove when front uses the new file path
-        # retrocompatibility
-        copyfile(
-            conf.output_dir / "organizations-bouquets.json",
-            f"dist/organizations-bouquets-{env}.json",
-        )
+        if conf.tag:
+            # TODO: can this be handled by the main update loop? datasets/services in bouquets should also be in universe?
+            verbose_print("Fetching additional organizations from bouquets...")
+            bouquets = datagouv.get_bouquets(conf.tag)
+            print(f"Found {len(bouquets)} bouquets with the universe tag.")
+            bouquet_orgs = uniquify(org for b in bouquets if (org := b.organization))
+            write_organizations_file(
+                conf.output_dir / "organizations-bouquets.json",
+                sorted(bouquet_orgs),
+            )
+            # FIXME: remove when front uses the new file path
+            # retrocompatibility
+            copyfile(
+                conf.output_dir / "organizations-bouquets.json",
+                f"dist/organizations-bouquets-{env}.json",
+            )
 
     finally:
         print(f"Done at {datetime.datetime.now():%c} in {time.time() - t_all:.0f} seconds.")


### PR DESCRIPTION
`tag` is currently only used by ecologie.datagouv to list orgs from its bouquets => don't force other verticals to configure it.

@eudespeyre FYI