### PR TITLE
fix: force add gitignored dist/*

### DIFF
--- a/.github/workflows/update-universes.yml
+++ b/.github/workflows/update-universes.yml
@@ -84,6 +84,7 @@ jobs:
           git push
           # -- end remove --
           pushd $ARTIFACTS_WORKTREE
+          # force add since dist/ is in .gitignore
           git add -f .
           git commit --no-verify -m "workflow: update daily run for ${{ matrix.universe }}"
           git pull --rebase origin ${{ env.ARTIFACTS_BRANCH }}


### PR DESCRIPTION
Fix https://github.com/opendatateam/udata-front-kit-universe/actions/runs/22889226344/job/66408645433

```
[9](https://github.com/opendatateam/udata-front-kit-universe/actions/runs/22889226344/job/66408645433#step:8:30)
The following paths are ignored by one of your .gitignore files:
dist
hint: Use -f if you really want to add them.
hint: Disable this message with "git config set advice.addIgnoredFile false"
Error: Process completed with exit code 1.
```