### PR TITLE
fix: run ecospheres last

### DIFF
--- a/.github/workflows/update-universes.yml
+++ b/.github/workflows/update-universes.yml
@@ -20,9 +20,9 @@ jobs:
       max-parallel: 1
       matrix:
         universe:
+          - culture-prod
           - ecospheres-demo
           - ecospheres-prod
-          - culture-prod
     environment: ${{ matrix.universe }}
     env:
       CONFIG_FILE: configs/${{ matrix.universe }}.yaml


### PR DESCRIPTION
This is a hack to ensure files directly under `dist`, i.e. `dist/organizations-*`, are ecospheres'. This issue will become irrelevant once we remove the flat backcompat `dist` layout and only have `dist/$site-$env/organizations-*`.
