### PR TITLE
chore: upgrade github actions/checkout

### DIFF
--- a/.github/workflows/update-universes.yml
+++ b/.github/workflows/update-universes.yml
@@ -36,7 +36,7 @@ jobs:
       # -- end remove --
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Fixes:

> Node.js 20 actions are deprecated.
> The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.
> [...]