### PR TITLE
feat: simpler check-sync

### DIFF
--- a/.github/workflows/check-sync.yml
+++ b/.github/workflows/check-sync.yml
@@ -32,7 +32,5 @@ jobs:
 
       - name: Check sync for ${{ inputs.universe }}
         env:
-          DATAGOUV_API_KEY: ${{ secrets.DATAGOUV_API_KEY  }}
-          GRIST_API_KEY: ${{ secrets.GRIST_API_KEY }}
           PYTHONUNBUFFERED: 1
         run: uv run universe check-sync configs/${{ inputs.universe }}.yaml

--- a/universe/check_sync.py
+++ b/universe/check_sync.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 from pathlib import Path
@@ -6,8 +5,7 @@ from pathlib import Path
 from minicli import cli, run
 
 from universe.config import Config
-from universe.datagouv import DatagouvApi, Organization
-from universe.grist import GristApi
+from universe.datagouv import DatagouvApi, Topic
 
 
 @cli
@@ -28,35 +26,28 @@ def check_sync(universe: Path, *extra_configs: Path):
         dry_run=True,
     )
 
-    grist = GristApi(
-        base_url=conf.grist.url,
-        table=conf.grist.table,
-        token=os.getenv("GRIST_API_KEY", conf.grist.token),
-    )
-
     topic_id = datagouv.get_topic_id(conf.topic)
 
-    orgs = set[Organization]()
-    grist_orgs = [e for e in grist.get_entries() if e.object_class is Organization]
-    for grist_org in grist_orgs:
-        org = datagouv.get_organization(grist_org.identifier)
-        if not org:
-            print(f"Unknown organization {grist_org.identifier}", file=sys.stderr)
-            continue
-        orgs.add(org)
-
     nb_errors = 0
-    for org in sorted(orgs):
-        datasets_wo_es = datagouv.get_topic_datasets_count(topic_id, org.id, use_search=False)
-        datasets_w_es = datagouv.get_topic_datasets_count(topic_id, org.id, use_search=True)
-        if datasets_w_es == datasets_wo_es:
-            print(f"✅ ({datasets_w_es}) — {org.name}")
+    for object_class in Topic.object_classes():
+        mongo_ids = {o.id for o in datagouv.get_topic_objects(topic_id, object_class, use_search=False)}
+        es_ids = {o.id for o in datagouv.get_topic_objects(topic_id, object_class, use_search=True)}
+
+        missing_from_es = mongo_ids - es_ids
+        stale_in_es = es_ids - mongo_ids
+
+        if not missing_from_es and not stale_in_es:
+            print(f"✅ {object_class.__name__}: {len(mongo_ids)}")
         else:
             nb_errors += 1
-            print(f"❌ ({datasets_w_es} / {datasets_wo_es}) — {org.name}", file=sys.stderr)
+            print(f"❌ {object_class.__name__}: Mongo={len(mongo_ids)} / ES={len(es_ids)}", file=sys.stderr)
+            for id in missing_from_es:
+                print(f"  missing from ES: {id}", file=sys.stderr)
+            for id in stale_in_es:
+                print(f"  stale in ES:     {id}", file=sys.stderr)
 
     if nb_errors:
-        print(f"\n{nb_errors} organizations are NOT in sync.", file=sys.stderr)
+        print(f"\n{nb_errors} object type(s) are NOT in sync.", file=sys.stderr)
         sys.exit(1)
 
 

--- a/universe/datagouv.py
+++ b/universe/datagouv.py
@@ -202,20 +202,7 @@ class DatagouvApi:
         r.raise_for_status()
         return r.json()["id"]
 
-    def get_topic_objects_count(
-        self, topic_id: str, object_class: type[TopicObject], use_search: bool = False
-    ) -> int:
-        if use_search:
-            url = f"{self.base_url}/api/2/{object_class.namespace()}/search/"
-        else:
-            version = "2" if object_class is Dataset else "1"
-            url = f"{self.base_url}/api/{version}/{object_class.namespace()}/"
-        params = {"topic": topic_id, "page_size": 1}
-        r = session.get(url, params=params)
-        r.raise_for_status()
-        return int(r.json()["total"])
-
-    @elapsed_and_count
+@elapsed_and_count
     def get_topic_elements(
         self, topic_id_or_slug: str, object_class: type[TopicObject]
     ) -> Sequence[TopicElement]:

--- a/universe/datagouv.py
+++ b/universe/datagouv.py
@@ -202,7 +202,7 @@ class DatagouvApi:
         r.raise_for_status()
         return r.json()["id"]
 
-@elapsed_and_count
+    @elapsed_and_count
     def get_topic_elements(
         self, topic_id_or_slug: str, object_class: type[TopicObject]
     ) -> Sequence[TopicElement]:

--- a/universe/datagouv.py
+++ b/universe/datagouv.py
@@ -202,9 +202,15 @@ class DatagouvApi:
         r.raise_for_status()
         return r.json()["id"]
 
-    def get_topic_datasets_count(self, topic_id: str, org_id: str, use_search: bool = False) -> int:
-        url = f"{self.base_url}/api/2/datasets{'/search' if use_search else ''}/"
-        params = {"topic": topic_id, "organization": org_id, "page_size": 1}
+    def get_topic_objects_count(
+        self, topic_id: str, object_class: type[TopicObject], use_search: bool = False
+    ) -> int:
+        if use_search:
+            url = f"{self.base_url}/api/2/{object_class.namespace()}/search/"
+        else:
+            version = "2" if object_class is Dataset else "1"
+            url = f"{self.base_url}/api/{version}/{object_class.namespace()}/"
+        params = {"topic": topic_id, "page_size": 1}
         r = session.get(url, params=params)
         r.raise_for_status()
         return int(r.json()["total"])
@@ -219,10 +225,13 @@ class DatagouvApi:
         return [TopicElement(id=o["id"], object=object_class(o["element"]["id"])) for o in objs]
 
     def get_topic_objects[T: TopicObject](
-        self, topic_id: str, object_class: type[T]
+        self, topic_id: str, object_class: type[T], use_search: bool = False
     ) -> Sequence[T]:
-        version = "2" if object_class is Dataset else "1"
-        url = f"{self.base_url}/api/{version}/{object_class.namespace()}/"
+        if use_search:
+            url = f"{self.base_url}/api/2/{object_class.namespace()}/search/"
+        else:
+            version = "2" if object_class is Dataset else "1"
+            url = f"{self.base_url}/api/{version}/{object_class.namespace()}/"
         params = {"topic": topic_id}
         objs = self._get_objects(url, params=params, fields=["id", "organization{id,name,slug}"])
         return [dacite.from_dict(object_class, o) for o in objs]


### PR DESCRIPTION
Stop using Grist as input, since parsing Grist rules is more complicated now. Just compare the Mongo entries vs the ES entries.

We also don't need secrets in workflow anymore.

Example output:

```
❯ uv run universe check-sync configs/accessibilite-demo.yaml
Running check of universe sync...
API for https://demo.data.gouv.fr ready.
❌ Dataset: Mongo=5 / ES=1
  missing from ES: 53699ed0a3a729239d205f91
  missing from ES: 67a3a1f4bb51187206427bdd
  missing from ES: 6088a697964b6e14db296bc7
  missing from ES: 57c8f98ea3a7290e4b230be4
  missing from ES: 61c2f189a6d223763c8b8e9e
  stale in ES:     6537eaa330451b3d27436a14
✅ Dataservice: 0
```