### PR TITLE
fix: workaround udata mask error

### DIFF
--- a/tests/datagouv_mock.py
+++ b/tests/datagouv_mock.py
@@ -285,7 +285,7 @@ class DatagouvMock:
             match=[
                 header_matcher(
                     {
-                        "X-Fields": f"data{{id,element{{id}},{','.join(INACTIVE_OBJECT_MARKERS)}}},next_page"
+                        "X-Fields": f"data{{id,element,{','.join(INACTIVE_OBJECT_MARKERS)}}},next_page"
                     }
                 ),
                 query_param_matcher({"class": object_class.model_name()}, strict_match=False),

--- a/universe/datagouv.py
+++ b/universe/datagouv.py
@@ -208,7 +208,7 @@ class DatagouvApi:
     ) -> Sequence[TopicElement]:
         url = f"{self.base_url}/api/2/topics/{topic_id_or_slug}/elements/"
         params = {"class": object_class.model_name()}
-        objs = self._get_objects(url, params=params, fields=["id", "element{id}"])
+        objs = self._get_objects(url, params=params, fields=["id", "element"])
         return [TopicElement(id=o["id"], object=object_class(o["element"]["id"])) for o in objs]
 
     def get_topic_objects[T: TopicObject](


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1086

Since udata 16.3.0 a request `/api/2/topics/.../elements/` with header `X-Fields: data{id,element{id}}` returns a 400 with the following message: "Mask error: Mask is inconsistent with model".

This is a low-impact workaround until udata fixes the issue (https://github.com/opendatateam/udata/issues/3755).