### PR TITLE
fix(ecologie): missing placeholder tokens in SIE/SIMM configs

### DIFF
--- a/configs/ecospheres-sieau-demo.yaml
+++ b/configs/ecospheres-sieau-demo.yaml
@@ -1,7 +1,9 @@
 topic: univers-sieau
 datagouv:
   url: https://demo.data.gouv.fr
+  token: CONFIGURE_ME
 grist:
   url: https://grist.numerique.gouv.fr/o/ecospheres/api/docs/iWqgJZ8yu9rrgXyXU7ie49
   table: SIE
+  token: CONFIGURE_ME
 output_dir: dist/ecospheres-sieau-demo

--- a/configs/ecospheres-sieau-demo.yaml
+++ b/configs/ecospheres-sieau-demo.yaml
@@ -1,3 +1,4 @@
+# WARNING: overload tokens with envvars or a separate config file to avoid leaking secrets
 topic: univers-sieau
 datagouv:
   url: https://demo.data.gouv.fr

--- a/configs/ecospheres-simm-demo.yaml
+++ b/configs/ecospheres-simm-demo.yaml
@@ -1,7 +1,9 @@
 topic: univers-simm
 datagouv:
   url: https://demo.data.gouv.fr
+  token: CONFIGURE_ME
 grist:
   url: https://grist.numerique.gouv.fr/o/ecospheres/api/docs/iWqgJZ8yu9rrgXyXU7ie49
   table: SIMM
+  token: CONFIGURE_ME
 output_dir: dist/ecospheres-simm-demo

--- a/configs/ecospheres-simm-demo.yaml
+++ b/configs/ecospheres-simm-demo.yaml
@@ -1,3 +1,4 @@
+# WARNING: overload tokens with envvars or a separate config file to avoid leaking secrets
 topic: univers-simm
 datagouv:
   url: https://demo.data.gouv.fr


### PR DESCRIPTION
```
Run uv run universe feed-universe configs/ecospheres-sieau-demo.yaml --fail-on-errors 2>&1 | tee logs/ecospheres-sieau-demo.log
Traceback (most recent call last):
  ...
  File "/home/runner/work/udata-front-kit-universe/udata-front-kit-universe/universe/feed_universe.py", line 177, in feed_universe
    conf = Config.from_files(universe, *extra_configs)
  File "/home/runner/work/udata-front-kit-universe/udata-front-kit-universe/universe/config.py", line 35, in from_files
    return dacite.from_dict(Config, conf, config=dacite.Config(cast=[Path]))
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/udata-front-kit-universe/udata-front-kit-universe/.venv/lib/python3.13/site-packages/dacite/core.py", line 69, in from_dict
    value = _build_value(type_=field_type, data=data[key], config=config)
  File "/home/runner/work/udata-front-kit-universe/udata-front-kit-universe/.venv/lib/python3.13/site-packages/dacite/core.py", line 107, in _build_value
    data = from_dict(data_class=type_, data=data, config=config)
  File "/home/runner/work/udata-front-kit-universe/udata-front-kit-universe/.venv/lib/python3.13/site-packages/dacite/core.py", line 81, in from_dict
    raise MissingValueError(field.name) from None
dacite.exceptions.MissingValueError: missing value for field "datagouv.token"
Error: Process completed with exit code 1.
```

I was surprised it still worked when I removed the placeholders, but I guess I didn't test under the right conditions: extra config file (ok) vs envvar (ko).